### PR TITLE
Added this.props as a spread attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ var React = require('react');
 
 var ContentEditable = React.createClass({
     render: function(){
-        return <div className="react-contenteditable"
+        return <div
+            {...this.props}
             onInput={this.emitChange} 
             onBlur={this.emitChange}
             contentEditable


### PR DESCRIPTION
I needed to be able to set some additional attributes on the top-level element of the content editable component. It seems to me like using `{...this.props}` as a spread attribute is the best way to do this. I did remove the default `className` since this would override any `className` set by the user of the component.