### PR TITLE
Made contentEditable enumerated.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var ContentEditable = React.createClass({
             {...this.props}
             onInput={this.emitChange} 
             onBlur={this.emitChange}
-            contentEditable
+            contentEditable="true"
             dangerouslySetInnerHTML={{__html: this.props.html}}></div>;
     },
 


### PR DESCRIPTION
The contentEditable attribute should adhere to the specification which states it is enumerated and not boolean and by that indicates it should have the value true or an empty string.

Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable