### PR TITLE
Add support for other tag types

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -1,8 +1,6 @@
 'use strict';
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -20,7 +18,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var ContentEditable = (function (_React$Component) {
+var ContentEditable = function (_React$Component) {
   _inherits(ContentEditable, _React$Component);
 
   function ContentEditable() {
@@ -37,14 +35,15 @@ var ContentEditable = (function (_React$Component) {
     value: function render() {
       var _this2 = this;
 
-      return _react2.default.createElement('div', _extends({}, this.props, {
+      return _react2.default.createElement(this.props.tagName || 'div', { ...this.props,
         ref: function ref(e) {
           return _this2.htmlEl = e;
         },
         onInput: this.emitChange,
         onBlur: this.emitChange,
         contentEditable: !this.props.disabled,
-        dangerouslySetInnerHTML: { __html: this.props.html } }));
+        dangerouslySetInnerHTML: { __html: this.props.html }
+      }, this.props.children);
     }
   }, {
     key: 'shouldComponentUpdate',
@@ -72,6 +71,6 @@ var ContentEditable = (function (_React$Component) {
   }]);
 
   return ContentEditable;
-})(_react2.default.Component);
+}(_react2.default.Component);
 
 exports.default = ContentEditable;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-contenteditable",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "React component representing a <div> with editable contents",
   "main": "./lib/react-contenteditable.js",
   "peerDependencies": {
@@ -21,12 +21,14 @@
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",
+    "babel-plugin-syntax-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-react-jsx": "^6.2.0",
     "babel-preset-es2015": "^6.1.18"
   },
   "babel": {
     "plugins": [
-      "transform-react-jsx"
+      "transform-react-jsx",
+      "babel-plugin-syntax-object-rest-spread"
     ],
     "presets": [
       "es2015"

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-class ContentEditable extends React.Component {
+export default class ContentEditable extends React.Component {
   constructor() {
     super();
     this.emitChange = this.emitChange.bind(this);
@@ -9,12 +9,14 @@ class ContentEditable extends React.Component {
   render() {
     return React.createElement(
       this.props.tagName || 'div',
-      Object.assign({}, this.props, {
-      ref: (e) => this.htmlEl = e,
-      onInput: this.emitChange,
-      onBlur: this.emitChange,
-      contentEditable: !this.props.disabled,
-      dangerouslySetInnerHTML: {__html: this.props.html}}),
+      {
+        ...this.props,
+        ref: (e) => this.htmlEl = e,
+        onInput: this.emitChange,
+        onBlur: this.emitChange,
+        contentEditable: !this.props.disabled,
+        dangerouslySetInnerHTML: {__html: this.props.html}
+      },
       this.props.children);
   }
 
@@ -39,5 +41,3 @@ class ContentEditable extends React.Component {
     this.lastHtml = html;
   }
 }
-
-module.exports = ContentEditable;

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -1,19 +1,21 @@
 import React from 'react';
 
-export default class ContentEditable extends React.Component {
+class ContentEditable extends React.Component {
   constructor() {
     super();
     this.emitChange = this.emitChange.bind(this);
   }
 
   render() {
-    return <div
-      {...this.props}
-      ref={(e) => this.htmlEl = e}
-      onInput={this.emitChange}
-      onBlur={this.emitChange}
-      contentEditable={!this.props.disabled}
-      dangerouslySetInnerHTML={{__html: this.props.html}}></div>;
+    return React.createElement(
+      this.props.tagName || 'div',
+      Object.assign({}, this.props, {
+      ref: (e) => this.htmlEl = e,
+      onInput: this.emitChange,
+      onBlur: this.emitChange,
+      contentEditable: !this.props.disabled,
+      dangerouslySetInnerHTML: {__html: this.props.html}}),
+      this.props.children);
   }
 
   shouldComponentUpdate(nextProps) {
@@ -37,3 +39,5 @@ export default class ContentEditable extends React.Component {
     this.lastHtml = html;
   }
 }
+
+module.exports = ContentEditable;


### PR DESCRIPTION
I have td tags that also use the contenteditable property. These changes will make other tag types usable by providing an optional tagName prop.

Also changed the exports default to module exports as it produced some weird error on my machine.

Hope you could review this soon!