### PR TITLE
Check for and handle browser-induced changes to innerHTML

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -50,12 +50,24 @@ var ContentEditable = function (_React$Component) {
   }, {
     key: 'shouldComponentUpdate',
     value: function shouldComponentUpdate(nextProps) {
-      return !this.htmlEl || nextProps.html !== this.htmlEl.innerHTML || this.props.disabled !== nextProps.disabled;
+      // We need not rerender if the change of props simply reflects the user's
+      // edits. Rerendering in this case would make the cursor/caret jump.
+      return(
+        // Rerender if there is no element yet... (somehow?)
+        !this.htmlEl
+        // ...or if html really changed... (programmatically, not by user edit)
+        || nextProps.html !== this.htmlEl.innerHTML
+        // ...or if editing is enabled or disabled.
+        || this.props.disabled !== nextProps.disabled
+      );
     }
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate() {
       if (this.htmlEl && this.props.html !== this.htmlEl.innerHTML) {
+        // Apparently React's VDOM (which gets outdated because we often prevent
+        // rerendering) thought that updating was not required. So we update the
+        // element manually now.
         this.htmlEl.innerHTML = this.props.html;
       }
     }

--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -69,6 +69,26 @@ var ContentEditable = function (_React$Component) {
         // rerendering) thought that updating was not required. So we update the
         // element manually now.
         this.htmlEl.innerHTML = this.props.html;
+
+        this.checkForImplicitReformat();
+      }
+    }
+  }, {
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      this.checkForImplicitReformat();
+    }
+  }, {
+    key: 'checkForImplicitReformat',
+    value: function checkForImplicitReformat() {
+      // If DOM node is still different, it is because the browser decided to
+      // reformat our HTML. We treat this reformatting as an edit and signal a
+      // change, so it will not lead to an undesired rerender.
+      var finalInnerHtml = this.htmlEl.innerHTML;
+      if (finalInnerHtml !== this.props.html) {
+        // Structure like the normal event, so the application can read the html
+        // from evt.target.value as usual.
+        this.props.onChange({ target: { value: finalInnerHtml } });
       }
     }
   }, {

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -38,6 +38,24 @@ export default class ContentEditable extends React.Component {
       // rerendering) thought that updating was not required. So we update the
       // element manually now.
       this.htmlEl.innerHTML = this.props.html;
+
+      this.checkForImplicitReformat()
+    }
+  }
+
+  componentDidMount() {
+    this.checkForImplicitReformat()
+  }
+
+  checkForImplicitReformat() {
+    // If DOM node is still different, it is because the browser decided to
+    // reformat our HTML. We treat this reformatting as an edit and signal a
+    // change, so it will not lead to an undesired rerender.
+    const finalInnerHtml = this.htmlEl.innerHTML;
+    if ( finalInnerHtml !== this.props.html ) {
+      // Structure like the normal event, so the application can read the html
+      // from evt.target.value as usual.
+      this.props.onChange({target: {value: finalInnerHtml}});
     }
   }
 

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -20,13 +20,24 @@ export default class ContentEditable extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return !this.htmlEl || nextProps.html !== this.htmlEl.innerHTML ||
-            this.props.disabled !== nextProps.disabled;
+    // We need not rerender if the change of props simply reflects the user's
+    // edits. Rerendering in this case would make the cursor/caret jump.
+    return (
+      // Rerender if there is no element yet... (somehow?)
+      !this.htmlEl
+      // ...or if html really changed... (programmatically, not by user edit)
+      || nextProps.html !== this.htmlEl.innerHTML
+      // ...or if editing is enabled or disabled.
+      || this.props.disabled !== nextProps.disabled
+    );
   }
 
   componentDidUpdate() {
     if ( this.htmlEl && this.props.html !== this.htmlEl.innerHTML ) {
-     this.htmlEl.innerHTML = this.props.html;
+      // Apparently React's VDOM (which gets outdated because we often prevent
+      // rerendering) thought that updating was not required. So we update the
+      // element manually now.
+      this.htmlEl.innerHTML = this.props.html;
     }
   }
 


### PR DESCRIPTION
Fixes #18.
The approach taken here is admittedly somewhat dubious. We generate a fake 'event'; that is, an object providing the new value in the `event.target.value` attribute. This would break listeners that expect the usual other attributes of an `onChange` event to be present. A cleaner option would be to change the module's API and not provide the onChange event itself, but only its `target.value` to the given handler (or pass the event itself as an optional second argument).