### PR TITLE
Add option userIsKing that prevents rerendering while editing

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -61,7 +61,7 @@ var ContentEditable = function (_React$Component) {
         // Rerender if there is no element yet... (somehow?)
         !this.htmlEl
         // ...or if html really changed... (programmatically, not by user edit)
-        || nextProps.html !== this.htmlEl.innerHTML
+        || nextProps.html !== this.htmlEl.innerHTML && nextProps.html !== this.props.html
         // ...or if editing is enabled or disabled.
         || this.props.disabled !== nextProps.disabled
       );

--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -55,12 +55,23 @@ var ContentEditable = function (_React$Component) {
   }, {
     key: 'shouldComponentUpdate',
     value: function shouldComponentUpdate(nextProps) {
-      return !this.htmlEl || nextProps.html !== this.htmlEl.innerHTML || this.props.disabled !== nextProps.disabled;
+      // We need not rerender if the change of props simply reflects the user's
+      // edits. Rerendering in this case would make the cursor/caret jump.
+      return(
+        // Rerender if there is no element yet... (somehow?)
+        !this.htmlEl
+        // ...or if html really changed... (programmatically, not by user edit)
+        || nextProps.html !== this.htmlEl.innerHTML
+        // ...or if editing is enabled or disabled.
+        || this.props.disabled !== nextProps.disabled
+      );
     }
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate() {
       if (this.htmlEl && this.props.html !== this.htmlEl.innerHTML) {
+        // Perhaps React (whose VDOM gets outdated because we often prevent
+        // rerendering) did not update the DOM. So we update it manually now.
         this.htmlEl.innerHTML = this.props.html;
       }
     }

--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -57,14 +57,22 @@ var ContentEditable = function (_React$Component) {
     value: function shouldComponentUpdate(nextProps) {
       // We need not rerender if the change of props simply reflects the user's
       // edits. Rerendering in this case would make the cursor/caret jump.
-      return(
-        // Rerender if there is no element yet... (somehow?)
-        !this.htmlEl
-        // ...or if html really changed... (programmatically, not by user edit)
-        || nextProps.html !== this.htmlEl.innerHTML && nextProps.html !== this.props.html
-        // ...or if editing is enabled or disabled.
-        || this.props.disabled !== nextProps.disabled
-      );
+
+      // Rerender if there is no element yet... (somehow?)
+      if (!this.htmlEl) return true;
+      // ...or if editing is being enabled or disabled...
+      if (this.props.disabled !== nextProps.disabled) return true;
+      // ...or if html is changed by application (unless we let user overrule).
+      if (nextProps.html !== this.htmlEl.innerHTML && nextProps.html !== this.props.html) {
+        if (this.props.userIsKing) {
+          // Do not disturb if the user is editing now.
+          return this.props.disabled || this.htmlEl !== document.activeElement;
+        } else return true;
+      }
+      // No need to update. The change in props was probably just the user's edit,
+      // so it is already reflected in the DOM. (note that React's virtual DOM may
+      // be out of sync with the real DOM now)
+      return false;
     }
   }, {
     key: 'componentDidUpdate',

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -27,15 +27,27 @@ export default class ContentEditable extends React.Component {
   shouldComponentUpdate(nextProps) {
     // We need not rerender if the change of props simply reflects the user's
     // edits. Rerendering in this case would make the cursor/caret jump.
-    return (
-      // Rerender if there is no element yet... (somehow?)
-      !this.htmlEl
-      // ...or if html really changed... (programmatically, not by user edit)
-      || ( nextProps.html !== this.htmlEl.innerHTML
-        && nextProps.html !== this.props.html )
-      // ...or if editing is enabled or disabled.
-      || this.props.disabled !== nextProps.disabled
-    );
+
+    // Rerender if there is no element yet... (somehow?)
+    if (!this.htmlEl)
+      return true;
+    // ...or if editing is being enabled or disabled...
+    if (this.props.disabled !== nextProps.disabled)
+      return true;
+    // ...or if html is changed by application (unless we let user overrule).
+    if (nextProps.html !== this.htmlEl.innerHTML
+        && nextProps.html !== this.props.html) {
+      if (this.props.userIsKing) {
+        // Do not disturb if the user is editing now.
+        return (this.props.disabled || this.htmlEl !== document.activeElement);
+      }
+      else
+        return true;
+    }
+    // No need to update. The change in props was probably just the user's edit,
+    // so it is already reflected in the DOM. (note that React's virtual DOM may
+    // be out of sync with the real DOM now)
+    return false;
   }
 
   componentDidUpdate() {

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -25,13 +25,23 @@ export default class ContentEditable extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return !this.htmlEl || nextProps.html !== this.htmlEl.innerHTML ||
-            this.props.disabled !== nextProps.disabled;
+    // We need not rerender if the change of props simply reflects the user's
+    // edits. Rerendering in this case would make the cursor/caret jump.
+    return (
+      // Rerender if there is no element yet... (somehow?)
+      !this.htmlEl
+      // ...or if html really changed... (programmatically, not by user edit)
+      || nextProps.html !== this.htmlEl.innerHTML
+      // ...or if editing is enabled or disabled.
+      || this.props.disabled !== nextProps.disabled
+    );
   }
 
   componentDidUpdate() {
     if ( this.htmlEl && this.props.html !== this.htmlEl.innerHTML ) {
-     this.htmlEl.innerHTML = this.props.html;
+      // Perhaps React (whose VDOM gets outdated because we often prevent
+      // rerendering) did not update the DOM. So we update it manually now.
+      this.htmlEl.innerHTML = this.props.html;
     }
   }
 

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -31,7 +31,8 @@ export default class ContentEditable extends React.Component {
       // Rerender if there is no element yet... (somehow?)
       !this.htmlEl
       // ...or if html really changed... (programmatically, not by user edit)
-      || nextProps.html !== this.htmlEl.innerHTML
+      || ( nextProps.html !== this.htmlEl.innerHTML
+        && nextProps.html !== this.props.html )
       // ...or if editing is enabled or disabled.
       || this.props.disabled !== nextProps.disabled
     );


### PR DESCRIPTION
Depending on the use case, it may actually be desirable to *not* let the application update the `div` at all while the user is editing it. The idea is to make updates flow only one direction: either from application to `div`, or, when the `div` is focussed and editing is enabled, from `div` to application.
Therefore I propose a setting `userIsKing` to enable this one-way mode, ensuring uninterrupted editing and thus also solving the problem of #18 (PR ~~#22~~ #27 should solve that issue for the case when `userIsKing=false`).
