### PR TITLE
Allow autofocus

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -1,12 +1,12 @@
 'use strict';
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 
 var _react = require('react');
 

--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -1,16 +1,20 @@
 'use strict';
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _reactDom2 = _interopRequireDefault(_reactDom);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -28,6 +32,7 @@ var ContentEditable = function (_React$Component) {
 
     var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(ContentEditable).call(this));
 
+    _this.autofocus = _this.autofocus.bind(_this);
     _this.emitChange = _this.emitChange.bind(_this);
     return _this;
   }
@@ -58,6 +63,11 @@ var ContentEditable = function (_React$Component) {
       if (this.htmlEl && this.props.html !== this.htmlEl.innerHTML) {
         this.htmlEl.innerHTML = this.props.html;
       }
+    }
+  }, {
+    key: 'autofocus',
+    value: function autofocus() {
+      _reactDom2.default.findDOMNode(this).focus();
     }
   }, {
     key: 'emitChange',

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 export default class ContentEditable extends React.Component {
   constructor() {
     super();
+    this.autofocus = this.autofocus.bind(this);
     this.emitChange = this.emitChange.bind(this);
   }
 
@@ -28,6 +30,10 @@ export default class ContentEditable extends React.Component {
     if ( this.htmlEl && this.props.html !== this.htmlEl.innerHTML ) {
      this.htmlEl.innerHTML = this.props.html;
     }
+  }
+
+  autofocus() {
+    ReactDOM.findDOMNode(this).focus();
   }
 
   emitChange(evt) {


### PR DESCRIPTION
Added possibility to get the component automatically focused. Use it like this:

```javascript
import React from 'react';
import ContentEditable from 'react-contenteditable';

class MyComponent extends React.Component {

    ...

    componentDidMount() {
        if (this.props.autoFocus) {
            this.contentEditable.autofocus();
        }
    }

    ...

    render() {
        return <ContentEditable {...props} ref={(c) => this.contentEditable = c} />
    }
}
```

Closes https://github.com/lovasoa/react-contenteditable/issues/20