### PR TITLE
Syntax modification and add handleReturn function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,19 @@ React component for a div with editable contents
       return {html: "<b>Hello <i>World</i></b>"};
     },
 
-    handleChange: function(evt){
-      this.setState({html: evt.target.value});
+    handleChange: function(value){
+      this.setState({content: value});
     },
 
     render: function(){
       return <ContentEditable
                 html={this.state.html} // innerHTML of the editable div
                 disabled={false}       // use true to disable edition
-                onChange={this.handleChange} // handle innerHTML change
+                onChange={this.handleChange} // handle ContentEditable change
+
+                // handle what you want to return from ContentEditable
+                // if handleReturn function is not given, return the innerHTML
+                handleReturn={(refEle) => refEle.innerText}
               />
     }
   });
@@ -28,4 +32,3 @@ React component for a div with editable contents
 ## Structure of this repository
  * [`lib/`](https://github.com/lovasoa/react-contenteditable/tree/master/lib) compiled javascript, usable directly in the browser
  * [`src/`](https://github.com/lovasoa/react-contenteditable/tree/master/src) source javascript. Uses JSX and ES6.
-

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -7,7 +7,7 @@ export default class ContentEditable extends React.Component {
   }
 
   render() {
-    var { tagName, html, onChange, ...props } = this.props;
+    var { tagName, html, onChange, handleReturn, ...props } = this.props;
 
     return React.createElement(
       this.props.tagName || 'div',
@@ -17,7 +17,7 @@ export default class ContentEditable extends React.Component {
         onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
-        dangerouslySetInnerHTML: {__html: this.props.html}
+        dangerouslySetInnerHTML: {__html: html}
       },
       this.props.children
     );
@@ -34,6 +34,7 @@ export default class ContentEditable extends React.Component {
         && nextProps.html !== this.props.html )
       // ...or if editing is enabled or disabled.
       || this.props.disabled !== nextProps.disabled
+      || this.props.className !== nextProps.className
     );
   }
 

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -7,21 +7,20 @@ export default class ContentEditable extends React.Component {
   }
 
   render() {
-    var props = {};
-    Object.assign(props, this.props);
-    delete props.tagName;
-    delete props.html;
+    var { tagName, html, onChange, ...props } = this.props;
 
     return React.createElement(
       this.props.tagName || 'div',
-      Object.assign({}, props, {
+      {
+        ...props,
         ref: (e) => this.htmlEl = e,
         onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
         dangerouslySetInnerHTML: {__html: this.props.html}
-      }),
-      this.props.children);
+      },
+      this.props.children
+    );
   }
 
   shouldComponentUpdate(nextProps) {
@@ -50,9 +49,12 @@ export default class ContentEditable extends React.Component {
     if (!this.htmlEl) return;
     var html = this.htmlEl.innerHTML;
     if (this.props.onChange && html !== this.lastHtml) {
-      evt.target = { value: html };
-      this.props.onChange(evt);
+      this.props.onChange(this._handleReturn(this.htmlEl));
     }
     this.lastHtml = html;
+  }
+
+  _handleReturn(refEle){
+    return this.props.handleReturn ? this.props.handleReturn(refEle) : refEle.innerHTML
   }
 }


### PR DESCRIPTION
There are some modifications.
1. replace `Object.assign()` with es6 spread operator
2. add a props function `handleReturn` to handle what you want from this component
`(refEle) => refEle.innerText` is an example
If `handleReturn`  is not given, return innerHTML as default
3. based on modification 2, `onChange` props function will take value user want.
4. The modifications are already updated in README.
5. Component should update when className is changed (flexible to make some style change)