### PR TITLE
replace Object.assign with es6 spread operator

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -14,6 +14,8 @@ var _react2 = _interopRequireDefault(_react);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -37,19 +39,21 @@ var ContentEditable = function (_React$Component) {
     value: function render() {
       var _this2 = this;
 
-      var props = {};
-      _extends(props, this.props);
-      delete props.tagName;
-      delete props.html;
+      var _props = this.props;
+      var tagName = _props.tagName;
+      var html = _props.html;
+      var onChange = _props.onChange;
 
-      return _react2.default.createElement(this.props.tagName || 'div', _extends({}, props, {
+      var props = _objectWithoutProperties(_props, ['tagName', 'html', 'onChange']);
+
+      return _react2.default.createElement(tagName || 'div', _extends({}, props, {
         ref: function ref(e) {
           return _this2.htmlEl = e;
         },
         onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
-        dangerouslySetInnerHTML: { __html: this.props.html }
+        dangerouslySetInnerHTML: { __html: html }
       }), this.props.children);
     }
   }, {
@@ -57,7 +61,7 @@ var ContentEditable = function (_React$Component) {
     value: function shouldComponentUpdate(nextProps) {
       // We need not rerender if the change of props simply reflects the user's
       // edits. Rerendering in this case would make the cursor/caret jump.
-      return(
+      return (
         // Rerender if there is no element yet... (somehow?)
         !this.htmlEl
         // ...or if html really changed... (programmatically, not by user edit)

--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
   "devDependencies": {
     "babel-cli": ">=6",
     "babel-plugin-add-module-exports": ">=0",
-    "babel-plugin-transform-object-assign": ">=6",
     "babel-preset-es2015": ">=6",
+    "babel-preset-stage-0": "^6.5.0",
     "react": "^15.2.1"
   },
   "babel": {
     "presets": [
-      "es2015"
+      "es2015",
+      "stage-0"
     ],
     "plugins": [
-      "transform-object-assign",
       "add-module-exports"
     ]
   },

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -7,20 +7,18 @@ export default class ContentEditable extends React.Component {
   }
 
   render() {
-    var props = {};
-    Object.assign(props, this.props);
-    delete props.tagName;
-    delete props.html;
+    var { tagName, html, onChange, ...props } = this.props;
 
     return React.createElement(
-      this.props.tagName || 'div',
-      Object.assign({}, props, {
+      tagName || 'div',
+      {
+        ...props,
         ref: (e) => this.htmlEl = e,
         onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
-        dangerouslySetInnerHTML: {__html: this.props.html}
-      }),
+        dangerouslySetInnerHTML: {__html: html}
+      },
       this.props.children);
   }
 


### PR DESCRIPTION
replace `Object.assign()` with es6 spread operator

Besides, I remove `babel-plugin-transform-object-assign` plugin and `stage-0` preset to compile successfully.