### PR TITLE
paste not styled-html but plain text

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -43,8 +43,9 @@ var ContentEditable = function (_React$Component) {
       var tagName = _props.tagName;
       var html = _props.html;
       var onChange = _props.onChange;
+      var pastePlain = _props.pastePlain;
 
-      var props = _objectWithoutProperties(_props, ['tagName', 'html', 'onChange']);
+      var props = _objectWithoutProperties(_props, ['tagName', 'html', 'onChange', 'pastePlain']);
 
       return _react2.default.createElement(tagName || 'div', _extends({}, props, {
         ref: function ref(e) {
@@ -53,6 +54,7 @@ var ContentEditable = function (_React$Component) {
         onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
+        onPaste: pastePlain ? this.onPaste : undefined,
         dangerouslySetInnerHTML: { __html: html }
       }), this.props.children);
     }
@@ -89,6 +91,13 @@ var ContentEditable = function (_React$Component) {
         this.props.onChange(evt);
       }
       this.lastHtml = html;
+    }
+  }, {
+    key: 'onPaste',
+    value: function onPaste(evt) {
+      evt.preventDefault();
+      var text = evt.clipboardData.getData('text/plain');
+      document.execCommand('insertHTML', false, text);
     }
   }]);
 

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -7,7 +7,7 @@ export default class ContentEditable extends React.Component {
   }
 
   render() {
-    var { tagName, html, onChange, ...props } = this.props;
+    var { tagName, html, onChange, pastePlain, ...props } = this.props;
 
     return React.createElement(
       tagName || 'div',
@@ -17,6 +17,7 @@ export default class ContentEditable extends React.Component {
         onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
+        onPaste: pastePlain ? this.onPaste : undefined,
         dangerouslySetInnerHTML: {__html: html}
       },
       this.props.children);
@@ -52,5 +53,11 @@ export default class ContentEditable extends React.Component {
       this.props.onChange(evt);
     }
     this.lastHtml = html;
+  }
+
+  onPaste(evt){
+    evt.preventDefault();
+    var text = evt.clipboardData.getData('text/plain');
+    document.execCommand('insertHTML', false, text);
   }
 }


### PR DESCRIPTION
### implement for #31 
now users can paste from every content to plain text to contenteditable when `pastePlain` props is `true`

But we may need to discuss what paste event we want.
paste with style or plain text?

my opinion is that this feature can be optional as my code.
provide flexible api for user to design UI( imagine a checkbox to decide the contenteditable-div's paste event)
And default is pasting with style( when contenteditable-div without `pastePlain` prop)

or paste plain text for **Simple**