### PR TITLE
Adding initial state

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -25,12 +25,13 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var ContentEditable = function (_React$Component) {
   _inherits(ContentEditable, _React$Component);
 
-  function ContentEditable() {
+  function ContentEditable(props) {
     _classCallCheck(this, ContentEditable);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(ContentEditable).call(this));
+    var _this = _possibleConstructorReturn(this, (ContentEditable.__proto__ || Object.getPrototypeOf(ContentEditable)).call(this));
 
     _this.emitChange = _this.emitChange.bind(_this);
+    _this.lastHtml = props.html;
     return _this;
   }
 

--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -78,6 +78,7 @@ var ContentEditable = function (_React$Component) {
         // Perhaps React (whose VDOM gets outdated because we often prevent
         // rerendering) did not update the DOM. So we update it manually now.
         this.htmlEl.innerHTML = this.props.html;
+        this.lastHtml = this.props.html;
       }
     }
   }, {

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -42,6 +42,7 @@ export default class ContentEditable extends React.Component {
       // Perhaps React (whose VDOM gets outdated because we often prevent
       // rerendering) did not update the DOM. So we update it manually now.
       this.htmlEl.innerHTML = this.props.html;
+      this.lastHtml = this.props.html;
     }
   }
 

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
 export default class ContentEditable extends React.Component {
-  constructor() {
+  constructor(props) {
     super();
     this.emitChange = this.emitChange.bind(this);
+    this.lastHtml = props.html;
   }
 
   render() {


### PR DESCRIPTION
Ran into a bug where if the content was pre-populated in the field at load time, it was triggering an onChange event when the field lost focus. 
