### PR TITLE
Feature/dom character data modified

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -28,7 +28,7 @@ var ContentEditable = function (_React$Component) {
   function ContentEditable() {
     _classCallCheck(this, ContentEditable);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(ContentEditable).call(this));
+    var _this = _possibleConstructorReturn(this, (ContentEditable.__proto__ || Object.getPrototypeOf(ContentEditable)).call(this));
 
     _this.emitChange = _this.emitChange.bind(_this);
     return _this;
@@ -39,18 +39,17 @@ var ContentEditable = function (_React$Component) {
     value: function render() {
       var _this2 = this;
 
-      var _props = this.props;
-      var tagName = _props.tagName;
-      var html = _props.html;
-      var onChange = _props.onChange;
-
-      var props = _objectWithoutProperties(_props, ['tagName', 'html', 'onChange']);
+      var _props = this.props,
+          tagName = _props.tagName,
+          html = _props.html,
+          onChange = _props.onChange,
+          props = _objectWithoutProperties(_props, ['tagName', 'html', 'onChange']);
 
       return _react2.default.createElement(tagName || 'div', _extends({}, props, {
         ref: function ref(e) {
           return _this2.htmlEl = e;
         },
-        onInput: this.emitChange,
+        // onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
         dangerouslySetInnerHTML: { __html: html }
@@ -69,6 +68,11 @@ var ContentEditable = function (_React$Component) {
         // ...or if editing is enabled or disabled.
         || this.props.disabled !== nextProps.disabled
       );
+    }
+  }, {
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      this.htmlEl.addEventListener("DOMCharacterDataModified", this.emitChange, false);
     }
   }, {
     key: 'componentDidUpdate',

--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -89,8 +89,8 @@ var ContentEditable = function (_React$Component) {
       if (!this.htmlEl) return;
       var html = this.htmlEl.innerHTML;
       if (this.props.onChange && html !== this.lastHtml) {
-        evt.target = { value: html };
-        this.props.onChange(evt);
+        // evt.target = { value: html };
+        this.props.onChange(html);
       }
       this.lastHtml = html;
     }

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -14,7 +14,7 @@ export default class ContentEditable extends React.Component {
       {
         ...props,
         ref: (e) => this.htmlEl = e,
-        onInput: this.emitChange,
+        // onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
         dangerouslySetInnerHTML: {__html: html}
@@ -36,6 +36,10 @@ export default class ContentEditable extends React.Component {
     );
   }
 
+  componentDidMount() {
+    this.htmlEl.addEventListener("DOMCharacterDataModified", this.emitChange, false);
+  }
+
   componentDidUpdate() {
     if ( this.htmlEl && this.props.html !== this.htmlEl.innerHTML ) {
       // Perhaps React (whose VDOM gets outdated because we often prevent
@@ -48,8 +52,8 @@ export default class ContentEditable extends React.Component {
     if (!this.htmlEl) return;
     var html = this.htmlEl.innerHTML;
     if (this.props.onChange && html !== this.lastHtml) {
-      evt.target = { value: html };
-      this.props.onChange(evt);
+      // evt.target = { value: html };
+      this.props.onChange(html);
     }
     this.lastHtml = html;
   }


### PR DESCRIPTION
Summary:

1. DOMCharacterDataModified event

`Input` event on `contenteditable` element is not supported on IE, I suggested to use `DOM mutation event` `DOMCharacterDataModified` to listen value change. 

2. event target is read only attribute

so if you update event target directly, it will cause execution error on IE environment. so I suggested to pass ` this.props.onChange(html)` for getting updated value instead of use event.

This change will break the interface in the usage
e.g, 
```jsx
handleChange: function(value){
  this.setState({html: value});
},
```

I have tested it on IE10, IE11, Chrome, Firefox and they works no problem. Feel free if you have any suggestion for this problem