### PR TITLE
fixing issue with programmatic updates not firing onChange events

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -59,11 +59,17 @@ var ContentEditable = function (_React$Component) {
     value: function shouldComponentUpdate(nextProps) {
       // We need not rerender if the change of props simply reflects the user's
       // edits. Rerendering in this case would make the cursor/caret jump.
+      var updatedProgrammatically = this.htmlEl && nextProps.html !== this.htmlEl.innerHTML && nextProps.html !== this.props.html;
+
+      if (updatedProgrammatically) {
+        this.lastHtml = nextProps.html;
+      }
+
       return (
         // Rerender if there is no element yet... (somehow?)
         !this.htmlEl
         // ...or if html really changed... (programmatically, not by user edit)
-        || nextProps.html !== this.htmlEl.innerHTML && nextProps.html !== this.props.html
+        || updatedProgrammatically
         // ...or if editing is enabled or disabled.
         || this.props.disabled !== nextProps.disabled
         // ...or if className changed

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -25,12 +25,19 @@ export default class ContentEditable extends React.Component {
   shouldComponentUpdate(nextProps) {
     // We need not rerender if the change of props simply reflects the user's
     // edits. Rerendering in this case would make the cursor/caret jump.
+    var updatedProgrammatically = this.htmlEl
+      && nextProps.html !== this.htmlEl.innerHTML
+      && nextProps.html !== this.props.html;
+
+    if (updatedProgrammatically) {
+      this.lastHtml = nextProps.html;
+    }
+
     return (
       // Rerender if there is no element yet... (somehow?)
       !this.htmlEl
       // ...or if html really changed... (programmatically, not by user edit)
-      || ( nextProps.html !== this.htmlEl.innerHTML
-        && nextProps.html !== this.props.html )
+      || updatedProgrammatically
       // ...or if editing is enabled or disabled.
       || this.props.disabled !== nextProps.disabled
       // ...or if className changed


### PR DESCRIPTION
This fixes [issue 58](https://github.com/lovasoa/react-contenteditable/issues/58) that I filed a week ago.

@lovasoa 