### PR TITLE
strip nbsp for comparison

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -22,6 +22,10 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var stripNbsp = function stripNbsp(str) {
+  return str.replace(/&nbsp;|\u202F|\u00A0/g, ' ');
+};
+
 var ContentEditable = function (_React$Component) {
   _inherits(ContentEditable, _React$Component);
 
@@ -70,7 +74,7 @@ var ContentEditable = function (_React$Component) {
       }
 
       // ...or if html really changed... (programmatically, not by user edit)
-      if (nextProps.html !== htmlEl.innerHTML && nextProps.html !== props.html) {
+      if (stripNbsp(nextProps.html) !== stripNbsp(htmlEl.innerHTML) && nextProps.html !== props.html) {
         return true;
       }
 

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+let stripNbsp = str => str.replace(/&nbsp;|\u202F|\u00A0/g, ' ');
+
 export default class ContentEditable extends React.Component {
   constructor() {
     super();
@@ -34,7 +36,10 @@ export default class ContentEditable extends React.Component {
     }
 
     // ...or if html really changed... (programmatically, not by user edit)
-    if (nextProps.html !== htmlEl.innerHTML && nextProps.html !== props.html) {
+    if (
+      stripNbsp(nextProps.html) !== stripNbsp(htmlEl.innerHTML) &&
+      nextProps.html !== props.html
+    ) {
       return true;
     }
 


### PR DESCRIPTION
Honestly I may have just been using this wrong, but I had an issue where the cursor position would reset to the beginning every time I typed a space into the div. Turns out this was because `shouldComponentUpdate` was returning true when a space was added. `htmlEl.innerHTML` had `&nbsp;` in its contents while `nextProps.html` had unicode `NO-BREAK SPACE`. These two are different of course, so the component would render. I'm not really sure where the white space is being transmogrified. I don't _think_ it's anything I was doing explicitly, but I haven't really chased it down either. So here's what I did.

Basically these whitespace characters are being normalized to regular spaces _only when comparing the values_, not when getting or setting the values. So in theory the only possible behavioral change is that the component will render in fewer cases, the API should not be affected at all.

Anyway, this is kinda slapped together and I don't claim to understand all the possible scenarios and permutations of user input, but this works for me.