### PR TITLE
Fixes "Cannot assign to read only property 'target' of object" error.

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -96,7 +96,13 @@ var ContentEditable = function (_React$Component) {
       if (!this.htmlEl) return;
       var html = this.htmlEl.innerHTML;
       if (this.props.onChange && html !== this.lastHtml) {
-        evt.target = { value: html };
+        // Clone event with Object.assign to avoid 
+        // "Cannot assign to read only property 'target' of object"
+        var evt = Object.assign({}, evt, { 
+          target: { 
+            value: html 
+          } 
+        });
         this.props.onChange(evt);
       }
       this.lastHtml = html;

--- a/src/react-contenteditable.js
+++ b/src/react-contenteditable.js
@@ -56,7 +56,13 @@ export default class ContentEditable extends React.Component {
     if (!this.htmlEl) return;
     var html = this.htmlEl.innerHTML;
     if (this.props.onChange && html !== this.lastHtml) {
-      evt.target = { value: html };
+      // Clone event with Object.assign to avoid 
+      // "Cannot assign to read only property 'target' of object"
+      var evt = Object.assign({}, evt, { 
+        target: { 
+          value: html 
+        } 
+      });
       this.props.onChange(evt);
     }
     this.lastHtml = html;


### PR DESCRIPTION
Clones the original event to avoid "Cannot assign to read only property 'target' of object" error.