### PR TITLE
Add prop to select full content on component update

### DIFF
--- a/lib/react-contenteditable.js
+++ b/lib/react-contenteditable.js
@@ -46,7 +46,7 @@ var ContentEditable = function (_React$Component) {
       var _props = this.props,
           tagName = _props.tagName,
           html = _props.html,
-          props = _objectWithoutProperties(_props, ['tagName', 'html']);
+          props = _objectWithoutProperties(_props, ['tagName', 'html', 'selectFullContent']);
 
       return _react2.default.createElement(tagName || 'div', _extends({}, props, {
         ref: function ref(e) {
@@ -93,6 +93,19 @@ var ContentEditable = function (_React$Component) {
         // rerendering) did not update the DOM. So we update it manually now.
         this.htmlEl.innerHTML = this.props.html;
       }
+      if (!this.props.disabled && this.props.selectFullContent){
+        this.selectFullContents();
+      }
+    }
+  }, {
+    key: 'selectFullContents',
+    value: function selectFullContents() {
+      var el = document.getElementById(this.props.id),
+          range = document.createRange(),
+          sel = window.getSelection();
+      range.selectNodeContents(el);
+      sel.removeAllRanges();
+      sel.addRange(range);
     }
   }, {
     key: 'emitChange',


### PR DESCRIPTION
Not sure this makes sense to add to this component, but I figured I'd make a PR to see. 

We ran into a use-case where users were toggling 'disabled' on an off, and for ease of use we prefered to have the full content selected when the user began editing (rather than having the cursor begin at the beginning of the content). 

Right now we just wrap the ContentEditable component with our own which includes this functionality but might be nice to merge up here. 

(pretty new to contributing, please let me know what you think)