### PR TITLE
Fix build typescript build (no default export for prop-types)

### DIFF
--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import deepEqual from 'fast-deep-equal';
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 
 
 function normalizeHtml(str: string): string {


### PR DESCRIPTION
Change the way of import of prop-types becouse of problems with the tsc compilation in relates projects

the error message was: popr-type don't have default export 

see https://stackoverflow.com/questions/44865952/types-prop-types-index-has-no-default-export for reference