### PR TITLE
Allow user to supply an innerRef prop and control the element ref from the outside

### DIFF
--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -138,5 +138,5 @@ export interface Props {
   tagName?: string,
   className?: string,
   style?: Object,
-  innerRef?: React.RefObject<HTMLDivElement>,
+  innerRef?: React.RefObject<Element>,
 }

--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -37,7 +37,7 @@ function replaceCaret(el: Element) {
  */
 export default class ContentEditable extends React.Component<Props> {
   lastHtml: string = this.props.html;
-  el = React.createElement();
+  el = React.createRef();
 
   getEl = () => (this.props.innerRef || this.el).current;
 

--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -16,7 +16,7 @@ function findLastTextNode(node: Node) : Node | null {
   return null;
 }
 
-function replaceCaret(el: Element) {
+function replaceCaret(el: HTMLElement) {
   // Place the caret at the end of the element
   const target = findLastTextNode(el);
   // do not move caret if element was not focused
@@ -37,7 +37,7 @@ function replaceCaret(el: Element) {
  */
 export default class ContentEditable extends React.Component<Props> {
   lastHtml: string = this.props.html;
-  el = React.createRef();
+  el = React.createRef<HTMLElement>();
 
   getEl = () => (this.props.innerRef || this.el).current;
 
@@ -135,5 +135,5 @@ export interface Props {
   tagName?: string,
   className?: string,
   style?: Object,
-  innerRef?: React.RefObject<Element>,
+  innerRef?: React.RefObject<HTMLElement>,
 }

--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -86,6 +86,7 @@ export default class ContentEditable extends React.Component<Props> {
     return props.disabled !== nextProps.disabled ||
       props.tagName !== nextProps.tagName ||
       props.className !== nextProps.className ||
+      props.innerRef !== nextProps.innerRef ||
       !deepEqual(props.style, nextProps.style);
   }
 

--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import deepEqual from 'fast-deep-equal';
 import * as PropTypes from 'prop-types';
 
-
 function normalizeHtml(str: string): string {
   return str && str.replace(/&nbsp;|\u202F|\u00A0/g, ' ');
 }
@@ -37,17 +36,10 @@ function replaceCaret(el: Element) {
  * A simple component for an html element with editable contents.
  */
 export default class ContentEditable extends React.Component<Props> {
+  lastHtml: string = this.props.html;
+  el = React.createElement();
 
-  lastHtml: string;
-  htmlEl: Element | null = null;
-
-  constructor(props: Props) {
-    super(props);
-    this.emitChange = this.emitChange.bind(this);
-    this.lastHtml = props.html;
-  }
-
-  getEl = () => (this.props.innerRef) ? this.props.innerRef.current : this.htmlEl;
+  getEl = () => (this.props.innerRef || this.el).current;
 
   render() {
     const { tagName, html, innerRef, ...props } = this.props;
@@ -56,7 +48,7 @@ export default class ContentEditable extends React.Component<Props> {
       tagName || 'div',
       {
         ...props,
-        ref: innerRef || (e => this.htmlEl = e),
+        ref: innerRef || this.el,
         onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
@@ -102,7 +94,7 @@ export default class ContentEditable extends React.Component<Props> {
     replaceCaret(el);
   }
 
-  emitChange(originalEvt: React.SyntheticEvent<any>) {
+  emitChange = (originalEvt: React.SyntheticEvent<any>) => {
     const el = this.getEl();
     if (!el) return;
 

--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -56,7 +56,7 @@ export default class ContentEditable extends React.Component<Props> {
       tagName || 'div',
       {
         ...props,
-        ref: innerRef ? innerRef : (e => this.htmlEl = e),
+        ref: innerRef || (e => this.htmlEl = e),
         onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
@@ -126,7 +126,11 @@ export default class ContentEditable extends React.Component<Props> {
     disabled: PropTypes.bool,
     tagName: PropTypes.string,
     className: PropTypes.string,
-    style: PropTypes.object
+    style: PropTypes.object,
+    innerRef: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.func,
+    ])
   }
 }
 

--- a/tests/src/__tests__/test.js
+++ b/tests/src/__tests__/test.js
@@ -72,12 +72,18 @@ async function initialOnChange(page, editComponent) {
   await expect(editComponent('history.length')).resolves.toBe(0);
 }
 
+async function createRef(page, editComponent) {
+  // We should know the element now
+  await expect(editComponent('el.current')).resolves.not.toBe(null);
+
+}
+
 const testFuns = [
   initialState,
   textTyped,
   deleteRewrite,
   resetStyle,
-  initialOnChange
+  initialOnChange,
 ];
 
 describe("react-contenteditable", async () => {
@@ -95,6 +101,17 @@ describe("react-contenteditable", async () => {
   for (let testFun of testFuns) {
     test(testFun.name, async () => {
       await page.goto(testFile);
+      await page.evaluate('render(false)');
+      await page.waitForSelector('#editableDiv');
+      const editComponent = f => page.evaluate('editComponent.' + f);
+      await testFun(page, editComponent);
+    });
+  }
+
+  for (let testFun of [...testFuns, createRef]) {
+    test('external ref ' + testFun.name, async () => {
+      await page.goto(testFile);
+      await page.evaluate('render(true)');
       await page.waitForSelector('#editableDiv');
       const editComponent = f => page.evaluate('editComponent.' + f);
       await testFun(page, editComponent);

--- a/tests/src/index.js
+++ b/tests/src/index.js
@@ -8,6 +8,7 @@ class EditComponent extends React.Component {
     this.state = { html: "", props: {} };
     this.history = [];
     this.changeCallback = _ => {};
+    this.el = React.createRef();
   }
 
   getHtml = () => this.state.html;
@@ -29,9 +30,12 @@ class EditComponent extends React.Component {
       style={{"height": "300px", "border": "1px dashed"}}
       html={this.state.html}
       onChange={this.handleChange}
+      innerRef={this.props.useInnerRef && this.el}
       {...this.state.props}
     />;
   };
 }
 
-window["editComponent"] = ReactDOM.render(<EditComponent />, document.getElementById("root"));
+window["render"] = (useInnerRef) => {
+  window["editComponent"] = ReactDOM.render(<EditComponent useInnerRef={useInnerRef} />, document.getElementById("root"));
+}


### PR DESCRIPTION
Fixes #103

Now you can get the ref of the div in a way that is more standard to React!

I would have preferred to get rid of the `htmlEl` prop altogether and use our own internal `createRef` if an external one is not provided, but that would have broken some people's current setup of directly accessing the `htmlEl` prop, as suggested in a previous bug report. There are two options to move forward on that though (none of which I implemented)
1. Make this a breaking change. 
2. Use `createRef` internally, make `htmlEl` prop a getter that accesses `ourOwnRef.current`

Happy to do either or leave it as is