### PR TITLE
Fix innerRef as function

### DIFF
--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -37,9 +37,9 @@ function replaceCaret(el: HTMLElement) {
  */
 export default class ContentEditable extends React.Component<Props> {
   lastHtml: string = this.props.html;
-  el = React.createRef<HTMLElement>();
+  el: any = typeof this.props.innerRef === 'function' ? { current: null } : React.createRef<HTMLElement>();
 
-  getEl = () => (this.props.innerRef || this.el).current;
+  getEl = () => (this.props.innerRef && typeof this.props.innerRef !== 'function' ? this.props.innerRef : this.el).current;
 
   render() {
     const { tagName, html, innerRef, ...props } = this.props;
@@ -48,7 +48,10 @@ export default class ContentEditable extends React.Component<Props> {
       tagName || 'div',
       {
         ...props,
-        ref: innerRef || this.el,
+        ref: typeof innerRef === 'function' ? (current: HTMLElement) => {
+          innerRef(current)
+          this.el.current = current
+        } : innerRef || this.el,
         onInput: this.emitChange,
         onBlur: this.props.onBlur || this.emitChange,
         contentEditable: !this.props.disabled,
@@ -135,5 +138,5 @@ export interface Props {
   tagName?: string,
   className?: string,
   style?: Object,
-  innerRef?: React.RefObject<HTMLElement>,
+  innerRef?: React.RefObject<HTMLElement> | Function,
 }

--- a/tests/src/__tests__/test.js
+++ b/tests/src/__tests__/test.js
@@ -53,6 +53,16 @@ async function resetStyle(page, editComponent) {
   await expectHtml(editComponent, "ab");
 }
 
+async function onChangeRef(page, editComponent) {
+
+  // set ref to function
+  await editComponent("setProps({ innerRef: () => {} })");
+
+  // type "a"
+  await page.type("#editableDiv", "a");
+  await expectHtml(editComponent, "a");
+}
+
 async function initialOnChange(page, editComponent) {
   // See: https://github.com/lovasoa/react-contenteditable/issues/42
 
@@ -84,6 +94,7 @@ const testFuns = [
   deleteRewrite,
   resetStyle,
   initialOnChange,
+  onChangeRef,
 ];
 
 describe("react-contenteditable", async () => {


### PR DESCRIPTION
The internal `el` reference breaks when `innerRef` is a function (from https://github.com/lovasoa/react-contenteditable/commit/1b91f870c234798a44b70a4d4ee16102e8b3f274).

This PR fixes the issue by simulating `ref` and storing the element manually.

I am not too familiar with typescript, so let me know if you need something different there. Tests included.

Thanks!