### PR TITLE
edit condition on isTargetFocused

### DIFF
--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -20,7 +20,7 @@ function replaceCaret(el: HTMLElement) {
   // Place the caret at the end of the element
   const target = findLastTextNode(el);
   // do not move caret if element was not focused
-  const isTargetFocused = document.activeElement === target;
+  const isTargetFocused = document.activeElement === el;
   if (target !== null && target.nodeValue !== null && isTargetFocused) {
     var range = document.createRange();
     var sel = window.getSelection();


### PR DESCRIPTION
There is a problem with a caret, if we slice text in html, it will always move in the beginning of content editable element. And I think that it's connected with focused target. You could see sandbox [here](https://codesandbox.io/s/2jv92o6moj).