### PR TITLE
Fix #161 by using PureComponent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,6 @@
       "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow==",
       "dev": true
     },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "prepare": "npm run compile"
   },
   "dependencies": {
-    "@types/prop-types": "^15.5.6",
-    "fast-deep-equal": "^2.0.1"
+    "@types/prop-types": "^15.5.6"
   }
 }

--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import deepEqual from 'fast-deep-equal';
 import * as PropTypes from 'prop-types';
 
 function normalizeHtml(str: string): string {
@@ -35,7 +34,7 @@ function replaceCaret(el: HTMLElement) {
 /**
  * A simple component for an html element with editable contents.
  */
-export default class ContentEditable extends React.Component<Props> {
+export default class ContentEditable extends React.PureComponent<Props> {
   lastHtml: string = this.props.html;
   el: any = typeof this.props.innerRef === 'function' ? { current: null } : React.createRef<HTMLElement>();
 
@@ -60,31 +59,6 @@ export default class ContentEditable extends React.Component<Props> {
         dangerouslySetInnerHTML: { __html: html }
       },
       this.props.children);
-  }
-
-  shouldComponentUpdate(nextProps: Props): boolean {
-    const { props } = this;
-    const el = this.getEl();
-
-    // We need not rerender if the change of props simply reflects the user's edits.
-    // Rerendering in this case would make the cursor/caret jump
-
-    // Rerender if there is no element yet... (somehow?)
-    if (!el) return true;
-
-    // ...or if html really changed... (programmatically, not by user edit)
-    if (
-      normalizeHtml(nextProps.html) !== normalizeHtml(el.innerHTML)
-    ) {
-      return true;
-    }
-
-    // Handle additional properties
-    return props.disabled !== nextProps.disabled ||
-      props.tagName !== nextProps.tagName ||
-      props.className !== nextProps.className ||
-      props.innerRef !== nextProps.innerRef ||
-      !deepEqual(props.style, nextProps.style);
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
This will remove the `shouldComponentUpdate` function and use `PureComponent` to still have a simple props check before updating the component.

Solves the issue described in #161 