### PR TITLE
Added onKeyPress props

### DIFF
--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -126,6 +126,7 @@ export default class ContentEditable extends React.Component<Props> {
     disabled: PropTypes.bool,
     tagName: PropTypes.string,
     className: PropTypes.string,
+    onKeyPress: PropTypes.func,
     style: PropTypes.object,
     innerRef: PropTypes.oneOfType([
       PropTypes.object,
@@ -140,6 +141,7 @@ export interface Props {
   onBlur?: Function,
   onKeyUp?: Function,
   onKeyDown?: Function,
+  onKeyPress?: Function,
   disabled?: boolean,
   tagName?: string,
   className?: string,

--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -123,6 +123,7 @@ export default class ContentEditable extends React.Component<Props> {
     onBlur: PropTypes.func,
     onKeyUp: PropTypes.func,
     onKeyDown:  PropTypes.func,
+    placeholder: PropTypes.string,
     disabled: PropTypes.bool,
     tagName: PropTypes.string,
     className: PropTypes.string,
@@ -146,5 +147,6 @@ export interface Props {
   tagName?: string,
   className?: string,
   style?: Object,
+  placeholder?: string,
   innerRef?: React.RefObject<HTMLElement> | Function,
 }


### PR DESCRIPTION
```
      // @ts-ignore
      <ContentEditable
        {...rest}
        onKeyPress={(event: React.KeyboardEvent<any>) => {
          if (event.key === 'Enter') {
            event.preventDefault();
           doStuff();
          }
        }}
       placeholder='Enter stuff'
      />
```

Currently i had to use @ts-ignore for this.