### PR TITLE
Make ContentEditableEvent exportable

### DIFF
--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -133,7 +133,7 @@ export default class ContentEditable extends React.Component<Props> {
   }
 }
 
-type ContentEditableEvent = React.SyntheticEvent<any, Event> & { target: { value: string } };
+export type ContentEditableEvent = React.SyntheticEvent<any, Event> & { target: { value: string } };
 type Modify<T, R> = Pick<T, Exclude<keyof T, keyof R>> & R;
 type DivProps = Modify<JSX.IntrinsicElements["div"], { onChange: ((event: ContentEditableEvent) => void) }>;
 


### PR DESCRIPTION
With `ContentEditableEvent` exportable, we can use it when needed:
```ts
import ContentEditable, { ContentEditableEvent } from "react-contenteditable";

export default class Example extends React.Component {
  handleChange(e: ContentEditableEvent) {
    doSomething(e);
  }

  render() {
    return (
      <ContentEditable onChange={(e) => this.handleChange(e)} />
    );
  }
}
```