### PR TITLE
Feat/component as tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class MyComponent extends React.Component {
               html={this.state.html} // innerHTML of the editable div
               disabled={false}       // use true to disable editing
               onChange={this.handleChange} // handle innerHTML change
-              tagName='article' // Use a custom HTML tag (uses a div by default)
+              tagName='article' // Use a custom HTML tag or a React component (uses a div by default)
             />
   };
 };
@@ -54,6 +54,7 @@ class MyComponent extends React.Component {
 |onBlur|called whenever the html element is [blurred](https://developer.mozilla.org/en-US/docs/Web/Events/blur)|Function|
 |onKeyUp|called whenever a key is released|Function|
 |onKeyDown|called whenever a key is pressed |Function|
+|tagName|custom HTML tag or a React component |String or React.ComponentType|
 |className|the element's [CSS class](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class)|String|
 |style|a collection of CSS properties to apply to the element|Object|
 

--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -123,7 +123,7 @@ export default class ContentEditable extends React.Component<Props> {
     html: PropTypes.string.isRequired,
     onChange: PropTypes.func,
     disabled: PropTypes.bool,
-    tagName: PropTypes.string,
+    tagName: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
     className: PropTypes.string,
     style: PropTypes.object,
     innerRef: PropTypes.oneOfType([
@@ -140,7 +140,7 @@ type DivProps = Modify<JSX.IntrinsicElements["div"], { onChange: ((event: Conten
 export interface Props extends DivProps {
   html: string,
   disabled?: boolean,
-  tagName?: string,
+  tagName?: string | React.ComponentType<any>,
   className?: string,
   style?: Object,
   innerRef?: React.RefObject<HTMLElement> | Function,

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -10219,8 +10219,20 @@
     "react-contenteditable": {
       "version": "file:..",
       "requires": {
-        "@types/prop-types": "^15.7.1",
-        "fast-deep-equal": "^2.0.1"
+        "fast-deep-equal": "^2.0.1",
+        "prop-types": "^15.7.1"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
       }
     },
     "react-dev-utils": {

--- a/tests/src/__tests__/test.js
+++ b/tests/src/__tests__/test.js
@@ -115,7 +115,35 @@ for (let useInnerRef of [false, true]) {
     for (let testFun of funs) {
       test(testFun.name, async () => {
         await page.goto(testFile);
-        await page.evaluate(`render(${useInnerRef})`);
+        await page.evaluate(`render({useInnerRef: ${useInnerRef}})`);
+        await page.waitForSelector('#editableDiv');
+        const editComponent = f => page.evaluate('editComponent.' + f);
+        await testFun(page, editComponent);
+      });
+    }
+  }, 16000);
+}
+
+const MyComponent = () => React.createElement("div", {className: "MyComponent"});
+
+for (let tagName of [`"div"`, `"section"`, MyComponent]) {
+  let namePart = (tagName ? "with" : "without");
+  describe(`react-contenteditable ${namePart} tagName`, () => {
+    let browser, page;
+
+    beforeAll(async () => {
+      browser = await puppeteer.launch();
+      page = await browser.newPage();
+    });
+
+    afterAll(async () => {
+      browser.close();
+    });
+
+    for (let testFun of testFuns) {
+      test(testFun.name, async () => {
+        await page.goto(testFile);
+        await page.evaluate(`render({tagName: ${tagName}})`);
         await page.waitForSelector('#editableDiv');
         const editComponent = f => page.evaluate('editComponent.' + f);
         await testFun(page, editComponent);

--- a/tests/src/index.tsx
+++ b/tests/src/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import ContentEditable from "react-contenteditable";
 
-type Props = { useInnerRef: boolean };
+type Props = { useInnerRef: boolean, tagName?: string | React.ComponentType<any> };
 type State = { html: string, props: {} };
 type RCEvent = { target: { value: string } };
 
@@ -12,7 +12,7 @@ class EditComponent extends React.Component<Props, State> {
   el: React.RefObject<HTMLElement>;
 
   constructor() {
-    super({ useInnerRef: false });
+    super({ useInnerRef: false, tagName: "div" });
     this.state = { html: "", props: {} };
     this.history = [];
     this.changeCallback = _ => { };
@@ -44,9 +44,15 @@ class EditComponent extends React.Component<Props, State> {
   };
 }
 
-(window as any)["render"] = (useInnerRef: boolean) => {
+(window as any)["render"] = ({
+  useInnerRef,
+  tagName
+}: {
+  useInnerRef: boolean,
+  tagName?: string | React.ComponentType<any>
+}) => {
   (window as any)["editComponent"] = ReactDOM.render(
-    <EditComponent useInnerRef={useInnerRef} />,
+    <EditComponent useInnerRef={useInnerRef} tagName={tagName} />,
     document.getElementById("root")
   );
 }


### PR DESCRIPTION
This PR removes the propType error shown when a React component is uses as `tagName`.

This project already supported it so the error was simply misleading.

I added tests and documented the property in the README.

closes #174 