### PR TITLE
Support contenteditable=false children

### DIFF
--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -6,19 +6,10 @@ function normalizeHtml(str: string): string {
   return str && str.replace(/&nbsp;|\u202F|\u00A0/g, ' ');
 }
 
-function findLastTextNode(node: Node): Node | null {
-  if (node.nodeType === Node.TEXT_NODE) return node;
-  let children = node.childNodes;
-  for (let i = children.length - 1; i >= 0; i--) {
-    let textNode = findLastTextNode(children[i]);
-    if (textNode !== null) return textNode;
-  }
-  return null;
-}
-
 function replaceCaret(el: HTMLElement) {
   // Place the caret at the end of the element
-  const target = findLastTextNode(el);
+  const target = document.createTextNode('');
+  el.appendChild(target);
   // do not move caret if element was not focused
   const isTargetFocused = document.activeElement === el;
   if (target !== null && target.nodeValue !== null && isTargetFocused) {


### PR DESCRIPTION
If your `ContentEditable` component contains spans or other children with `contenteditable=false`, you'll lose your cursor if you delete until you reach that node.

Instead of finding the last text node, assuming it's editable, and setting the caret at its tail, a clean way to fix this is to create an empty text element, append it to `el`, and set the caret there. This seems to always place the caret at the end of the `ContentEditable`, even when dealing with non-selectable children.