### PR TITLE
Always update this.lastHtml (#173)

### DIFF
--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -87,8 +87,9 @@ export default class ContentEditable extends React.Component<Props> {
     // Perhaps React (whose VDOM gets outdated because we often prevent
     // rerendering) did not update the DOM. So we update it manually now.
     if (this.props.html !== el.innerHTML) {
-      el.innerHTML = this.lastHtml = this.props.html;
+      el.innerHTML = this.props.html;
     }
+    this.lastHtml = this.props.html;
     replaceCaret(el);
   }
 


### PR DESCRIPTION
The bug can be seen here: https://codesandbox.io/s/simple-rich-text-editor-in-react-p2485
When deleting text content for the first time the onChange prop is not called.