### PR TITLE
Placeholder prop support in TypeScript

### DIFF
--- a/src/react-contenteditable.tsx
+++ b/src/react-contenteditable.tsx
@@ -135,4 +135,5 @@ export interface Props extends DivProps {
   className?: string,
   style?: Object,
   innerRef?: React.RefObject<HTMLElement> | Function,
+  placeholder?: string
 }


### PR DESCRIPTION
Adding **placeholder** member in **Props** interface to enable support for TypeScript